### PR TITLE
Allow slider to smoothly change map colors

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -46,6 +46,7 @@ svg {
     paint-order: stroke fill;
     stroke-width: 2;
     stroke: #0f0f0f;
+    transition: opacity 200ms;
 }
 
 div .cholorpleth {

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -157,7 +157,6 @@ export default class Map extends Component {
         }
         tooltip.style("opacity", "0.0"); 
       })
-      .transition().delay(200)
       .attr('d', path)
       .attr('fill', function(d,i) {
         return colorScale(amountAllocated[i].value)
@@ -246,7 +245,6 @@ export default class Map extends Component {
     .enter().append("rect")
     .attr("x", 820)
     .attr("y", function(d,i) { return d })
-    .transition().delay(200)
     .attr("width", 50)
     .attr("height", 60)
     .attr("fill", function(d,i) {


### PR DESCRIPTION
This change lets you drag the timeline window and the map will smoothly change the map colors and scale, without visibly "redrawing" the whole map each time. Also adds a transition effect to the map piece the user hovers over.